### PR TITLE
displaying tags in info pane

### DIFF
--- a/views/partials/browser/panel-info.nunj
+++ b/views/partials/browser/panel-info.nunj
@@ -4,6 +4,16 @@
             <strong class="Meta-key">Handle:</strong>
             <span class="Meta-value">@{{ entity.handle }}</span>
         </li>
+        {% if entity.tags.length > 1 %}
+        <li class="Meta-item">
+            <strong class="Meta-key">Tags:</strong>
+            <span class="Meta-value">
+                {% for tag in entity.tags %}
+                    <span>{% if tag %}{{ tag }}</span>{% if not loop.last %}, {% endif %}{% endif %}
+                {% endfor %}
+            </span>
+        </li>
+        {% endif %}
         {% if entity.isComponent %}
         {% set variants = entity.variants() %}
         {% else %}


### PR DESCRIPTION
added a simple view of the tags in the info pane.
the first tag in the array seems to always be empty? 
i just put a null check around it.