### PR TITLE
Add user-configurable `beautify` filter

### DIFF
--- a/src/filters.js
+++ b/src/filters.js
@@ -24,12 +24,21 @@ module.exports = function(theme, env, app){
     });
 
     env.engine.addFilter('beautify', function(str) {
-        return beautifyHTML(str, {
-            // TODO: move to config
-            indent_size: 4,
-            preserve_newlines: true,
-            max_preserve_newlines: 1
-        });
+        const defaults = {
+          indent_size: 4,
+          preserve_newlines: true,
+          max_preserve_newlines: 1
+        };
+
+        let beautifyOptions = theme.getOption('beautify') || {};
+
+        if (typeof beautifyOptions === 'function') {
+            return beautifyOptions(str);
+        }
+
+        beautifyOptions = _.merge({}, defaults, beautifyOptions);
+
+        return beautifyHTML(str, beautifyOptions);
     });
 
     env.engine.addFilter('resourceUrl', function(str) {


### PR DESCRIPTION
I've really been enjoying using Fractal - thank you very much for all the effort that's been put into it!

The main pain point I've had is around HTML beautification, which I've attempted to address in this PR. Basically it uses the theme config's `beautify` property as a custom beautification function or options for JS Beautify:
```js
const theme = mandelbrot({
  beautify: (str) => {
    // Beautification happens here
  }
})
```
Or:
```js
const theme = mandelbrot({
  beautify: {
    indent_size: 2
  }
})
```

Let me know if there's anything in there you'd like me to reimplement.