### PR TITLE
#60 Limit the width of images in the documentation section

### DIFF
--- a/assets/scss/components/_prose.scss
+++ b/assets/scss/components/_prose.scss
@@ -73,6 +73,10 @@
         background-color: rgba($color-text, 0.075);
     }
 
+    img {
+        max-width: 100%;
+    }
+
     p code,
     li code {
         padding: 0.125rem;


### PR DESCRIPTION
This stops large images from overflowing the container and breaking the layout.