### PR TITLE
add "last updated" info

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 The default web UI theme for Fractal.
 
 See the Fractal [documentation](http://fractal.build/guide) for details on configuration and usage.
+
+In order to get a locale aware date for the 'last updated' text, install the
+[full-icu](https://github.com/unicode-org/full-icu-npm) module.

--- a/assets/scss/components/_tree.scss
+++ b/assets/scss/components/_tree.scss
@@ -100,3 +100,10 @@
         }
     }
 }
+
+.Tree-aside {
+    @include font(caption);
+    margin: 1rem 1rem 0;
+    padding-top: 0.375rem;
+    opacity: 0.7;
+}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@frctl/fractal": "^1.1.0-alpha.0",
-    "lodash": "^4.12.0",
-    "js-beautify": "^1.6.2"
+    "js-beautify": "^1.6.2",
+    "lodash": "^4.12.0"
   }
 }

--- a/src/theme.js
+++ b/src/theme.js
@@ -26,6 +26,7 @@ module.exports = function(options){
     config.styles  = [].concat(config.styles).concat(config.stylesheet).filter(url => url).map(url => (url === 'default' ? `/${config.static.mount}/css/${config.skin}.css` : url));
     config.scripts = [].concat(config.scripts).filter(url => url).map(url => (url === 'default' ? `/${config.static.mount}/js/mandelbrot.js` : url));
     config.favicon = config.favicon || `/${config.static.mount}/favicon.ico`;
+    config.now = new Date();
 
     const assetSourceName = 'components';
 

--- a/views/layouts/frame.nunj
+++ b/views/layouts/frame.nunj
@@ -18,9 +18,10 @@
         </div>
 
         <div class="Frame-handle" data-role="frame-resize-handle"></div>
-        
+
         <div class="Frame-panel Frame-panel--sidebar" data-role="sidebar">
             {% include 'partials/navigation/navigation.nunj' %}
+            {% include 'partials/last-update.nunj' %}
         </div>
     </div>
 </div>

--- a/views/partials/last-update.nunj
+++ b/views/partials/last-update.nunj
@@ -1,0 +1,7 @@
+<div class="Tree-aside">
+    Built on:
+    <time datetime="{{ frctl.theme.get('now').toISOString() }}"
+          title="{{ frctl.theme.get('now').toLocaleString(frctl.theme.get('lang')) }}">
+        {{ frctl.theme.get('now').toLocaleDateString(frctl.theme.get('lang')) }}
+    </time>
+</div>


### PR DESCRIPTION
#25
This MR adds a 'Built on' label at the bottom of the navigation bar. The full date and time are displayed on hover. 

![screenshot 2017-07-23 17 50 11](https://user-images.githubusercontent.com/288516/28500805-70a77536-6fcf-11e7-9cee-1ecaab166b57.png)

The date should be localized. Hovever, I could not really get this to work yet.