### PR TITLE
Append allow-modals to demo iframe

### DIFF
--- a/views/partials/pen/preview.nunj
+++ b/views/partials/pen/preview.nunj
@@ -8,7 +8,7 @@
                 class="Preview-iframe"
                 data-role="window"
                 src="{{ previewUrl }}"
-                sandbox="allow-same-origin allow-scripts allow-forms"
+                sandbox="allow-same-origin allow-scripts allow-forms allow-modals"
                 {% if entity.display %} style="{% for property, value in entity.display %}{{ property }}: {{ value }} !important; {% endfor %}"{% endif %}
                 marginwidth="0" marginheight="0" frameborder="0" vspace="0" hspace="0" scrolling="yes">
             </iframe>


### PR DESCRIPTION
Sometimes it's useful to make a demo with the use of window.alert() or window.prompt(), and `allow-modals` needs to be set on the iframe in order to use those features.