### PR TITLE
Improve header layout with long title

### DIFF
--- a/assets/scss/components/_header.scss
+++ b/assets/scss/components/_header.scss
@@ -15,11 +15,14 @@
     font-size: 1.125rem; // 18px
     line-height: (24 / 18);
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .Header-button {
     @include border-inline(end, 1px solid rgba($color-header-content, 0.25));
     display: block;
+    flex-shrink: 0;
     border: 0;
     height: 3rem;
     width: 3rem;


### PR DESCRIPTION
Fixes #70

### Before

![before](https://user-images.githubusercontent.com/793344/52862690-20cfe000-3136-11e9-9602-e0cdb86b310d.png)

### After

![after](https://user-images.githubusercontent.com/793344/52862697-23cad080-3136-11e9-967a-de7bfa37e71b.png)
