### PR TITLE
Make header button usable with keyboard

### DIFF
--- a/assets/scss/components/_header.scss
+++ b/assets/scss/components/_header.scss
@@ -30,11 +30,6 @@
     color: inherit;
     cursor: pointer;
 
-    &:focus,
-    &:active {
-        outline: none;
-    }
-
     &:hover {
         background-color: rgba($color-header-content, 0.05);
     }


### PR DESCRIPTION
These lines made it impossible for the user to see where they are, if they use a keyboard to navigate through their Fractal instance and get to the header button.

By removing them, the browser default focus outline will be shown, so that the user can see that they are on the header button.