### PR TITLE
Move scrolling of the sidebar to after the state has been applied

### DIFF
--- a/assets/js/components/frame.js
+++ b/assets/js/components/frame.js
@@ -23,7 +23,6 @@ module.exports = function(element){
 
     let sidebarWidth   = utils.isSmallScreen() ? sidebarMin : storage.get(`frame.sidebar`, sidebar.outerWidth());
     let sidebarState   = utils.isSmallScreen() ? 'closed' : storage.get(`frame.state`, 'open');
-    let scrollPos      = storage.get(`frame.scrollPos`, 0);
     let dragOccuring   = false;
     let isInitialClose = false;
     let handleClicks   = 0;
@@ -34,8 +33,6 @@ module.exports = function(element){
         isInitialClose = true;
         closeSidebar();
     }
-
-    sidebar.scrollTop(scrollPos);
 
     handle.on('mousedown', e => {
         handleClicks++;
@@ -90,6 +87,10 @@ module.exports = function(element){
         setTimeout(function(){
             dragOccuring = false;
         }, 200);
+    });
+    events.on('scroll-sidebar', function() {
+        const scrollPos = storage.get(`frame.scrollPos`, 0);
+        sidebar.scrollTop(scrollPos);
     });
 
     events.on('data-changed', function(){

--- a/assets/js/components/tree.js
+++ b/assets/js/components/tree.js
@@ -28,6 +28,7 @@ class Tree {
         }
         this._state = jQuery.unique(this._state);
         this._applyState();
+        events.trigger('scroll-sidebar');
         events.on('main-content-preload', (e, url) => {
             this.selectItem(getTreeUrl(url));
         });


### PR DESCRIPTION
Fix for frctl/fractal#220
On a static build, applying the state after the scroll was made had the navigation jumping around when many collections where open at the same time