### PR TITLE
🚑 Fix prepack script for build

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "start": "gulp watch",
     "build": "gulp",
-    "prepack": "npm run build"
+    "prepack": "npm install && npm run build"
   },
   "peerDependencies": {
     "@frctl/fractal": ">= 1.1.0-alpha.0 < 2"


### PR DESCRIPTION
The error `sh: gulp: command not found` occurred, so I fixed.