### PR TITLE
allow users to customize highlight.js theme

### DIFF
--- a/assets/scss/components/_browser.scss
+++ b/assets/scss/components/_browser.scss
@@ -75,17 +75,17 @@
     }
 
     .Code {
-        background-color: $color-background-offset;
-
-        pre {
-            background-color: $color-background-offset;
-            padding: 0;
-        }
+        width: 100%;
+        padding: 0;
     }
 
     > .Meta {
         flex-basis: 100%;
     }
+}
+
+.Browser-code {
+    padding: 0;
 }
 
 .Browser-isEmptyNote {

--- a/assets/scss/components/_prose.scss
+++ b/assets/scss/components/_prose.scss
@@ -1,6 +1,7 @@
 .Prose {
     @include font(body);
     max-width: 44em;
+    width: 100%;
     font-feature-settings: "liga", "dlig", "kern", "onum";
     hanging-punctuation: first;
 
@@ -68,21 +69,10 @@
         opacity: 0.75;
     }
 
-    code {
-        padding: 0.125rem;
-        background-color: rgba($color-text, 0.075);
-    }
-
-    pre > code {
-        padding: 0;
-        background: 0;
-    }
-
     pre {
         padding: 0.125rem 0.5rem;
         margin: 1rem -0.5rem;
         overflow: auto;
-        background-color: rgba($color-text, 0.075);
     }
 
     img {

--- a/assets/scss/core/_all.scss
+++ b/assets/scss/core/_all.scss
@@ -17,7 +17,6 @@ $mq-breakpoints: (
 // -----------------------------------------------------------------------------
 @import "normalize.css/normalize";
 @import "sass-mq/_mq";
-@import "highlight.js/styles/github";
 
 // -----------------------------------------------------------------------------
 // Core

--- a/assets/scss/highlight.scss
+++ b/assets/scss/highlight.scss
@@ -1,0 +1,1 @@
+@import "highlight.js/styles/github";

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,7 +61,7 @@ $color-link: ${skin.links};
 }
 
 function bundleCss(watch) {
-    return src('./assets/scss/skins/*.scss')
+    return src(['./assets/scss/skins/*.scss', './assets/scss/highlight.scss'])
         .pipe(stylelint({
             reporters: [{formatter: 'string', console: true}]
         }))

--- a/src/theme.js
+++ b/src/theme.js
@@ -12,6 +12,7 @@ module.exports = function(options){
         rtl: false,
         lang: 'en',
         styles: 'default',
+        highlightStyles: 'default',
         scripts: 'default',
         format: 'json',
         static: {
@@ -29,9 +30,12 @@ module.exports = function(options){
         }
     });
 
+    const uiStyles = [].concat(config.styles).concat(config.stylesheet).filter(url => url).map(url => (url === 'default' ? `/${config.static.mount}/css/${config.skin}.css` : url));
+    const highlightStyles = [].concat(config.highlightStyles).filter(url => url).map(url => (url === 'default' ? `/${config.static.mount}/css/highlight.css` : url));
+
     config.panels  = config.panels || ['html', 'view', 'context', 'resources', 'info', 'notes'];
     config.nav     = config.nav || ['search', 'components', 'docs', 'assets', 'information'];
-    config.styles  = [].concat(config.styles).concat(config.stylesheet).filter(url => url).map(url => (url === 'default' ? `/${config.static.mount}/css/${config.skin}.css` : url));
+    config.styles  = [].concat(uiStyles).concat(highlightStyles);
     config.scripts = [].concat(config.scripts).filter(url => url).map(url => (url === 'default' ? `/${config.static.mount}/js/mandelbrot.js` : url));
     config.favicon = config.favicon || `/${config.static.mount}/favicon.ico`;
     config.now     = new Date();

--- a/views/partials/browser/panel-context.nunj
+++ b/views/partials/browser/panel-context.nunj
@@ -1,5 +1,5 @@
 <div class="Browser-panel Browser-code" data-role="tab-panel" id="browser-{{ entity.id }}-panel-context">
-    <code class="Code Code--lang-{{ frctl.theme.get('format') }}">
+    <code class="Code Code--lang-{{ frctl.theme.get('format') }} hljs">
         {% if not entity.isCollated or entity.isVariant or entity.variants().size == 1 %}
             {% if entity.hasContext() | async %}
             <pre>{{ entity.getResolvedContext()  | async | format(frctl.theme.get('format')) | highlight(frctl.theme.get('format')) }}</pre>

--- a/views/partials/browser/panel-html.nunj
+++ b/views/partials/browser/panel-html.nunj
@@ -1,6 +1,6 @@
 {% import "macros/render.nunj" as render %}
 <div class="Browser-panel Browser-code is-active" data-role="tab-panel" id="browser-{{ entity.id }}-panel-html">
-    <code class="Code Code--lang-html">
+    <code class="Code Code--lang-html hljs">
         {% if not entity.isCollated or entity.isVariant or entity.variants().size == 1 %}
         <pre>{{ render.entity(entity.render(null, renderEnv, {preview: false, collate: false}) | async(true)) | trim }}</pre>
         {% else %}

--- a/views/partials/browser/panel-resources.nunj
+++ b/views/partials/browser/panel-resources.nunj
@@ -23,7 +23,7 @@
                             {% if resource.isBinary and resource.isImage %}
                                 <img src="{{ path(frctl.theme.urlFromRoute('component-resource', {handle: compHandle, asset:resource.base} )) }}">
                             {% elif not resource.isBinary %}
-                            <code class="Code Code--lang-{{ resource.lang }} FileBrowser-code">
+                            <code class="Code Code--lang-{{ resource.lang }} FileBrowser-code hljs">
                                 <pre>{{ resource.contents | highlight(resource.lang) }}</pre>
                             </code>
                             {% else %}

--- a/views/partials/browser/panel-view.nunj
+++ b/views/partials/browser/panel-view.nunj
@@ -1,5 +1,5 @@
 <div class="Browser-panel Browser-code" data-role="tab-panel" id="browser-{{ entity.id }}-panel-view">
-    <code class="Code Code--lang-{{ entity.editorMode | default(entity.lang) }}">
+    <code class="Code Code--lang-{{ entity.editorMode | default(entity.lang) }} hljs">
         <pre>{{ entity.getPreviewContent() | async | trim | highlight(entity.editorMode | default(entity.lang)) | linkRefs(entity) }}</pre>
     </code>
 </div>


### PR DESCRIPTION
Should resolve frctl/fractal#484 on the theme side.

Some notes:
- All code blocks are now styled by the highlight.js theme.
- For full support, it needs frctl/fractal#578 merged in and released. I think we should do a mandelbrot release, then merge frctl/fractal#578 and do a core release with the new mandelbrot.
- The highlight.scss is a separate style entry because we should only load one highlight.js theme at a time. This means that the user needs to be able to opt out of loading our default hljs theme.
- I added the configurability of this under a new `highlightStyles` key. This is partially to improve backwards compatibility - if we were to add the highlight to the `styles` key (e,g, `styles: ['default', 'highlight']`), users who have customized the styles array would get broken styles. I also think the code highlighting is a very special part of the web ui theme that it's fair if it can be configured separately.